### PR TITLE
fix: adding a workaround in readme so npx command doesn't break with prettier version >=3

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ With [`npx`](https://npm.im/npx):
 npx -p prettier@^2 -p pretty-quick pretty-quick
 ```
 
-> Note: You can (_should_) change `latest` to a specific version of Prettier.
+> Note: You can (_should_) change `@^2` to a specific version of Prettier.
 
 With `npm`:
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ yarn pretty-quick
 With [`npx`](https://npm.im/npx):
 
 ```shellsession
-npx -p prettier@latest -p pretty-quick pretty-quick
+npx -p prettier@^2 -p pretty-quick pretty-quick
 ```
 
 > Note: You can (_should_) change `latest` to a specific version of Prettier.


### PR DESCRIPTION
Workaround due to #164 
* Added a workaround to use a downgraded version of prettier.