### PR TITLE
test(#73/#125): add glob regex group cases

### DIFF
--- a/test/pattern.spec.ts
+++ b/test/pattern.spec.ts
@@ -22,7 +22,7 @@ describe('match pattern', () => {
       '/src/should-not-be-included/hello/zoo.js': "export const zoo = 'zoo'",
     })
 
-    // @ts-expect-error -- Need to find a better way to moch this
+    // @ts-expect-error -- Need to find a better way to mock this
     // eslint-disable-next-line @typescript-eslint/no-unsafe-call
     execa.sync.mockImplementation((_command: string, args: string[]) => {
       switch (args[0]) {

--- a/test/pattern.spec.ts
+++ b/test/pattern.spec.ts
@@ -1,0 +1,62 @@
+import execa from 'execa'
+import mock from 'mock-fs'
+
+import prettyQuick from 'pretty-quick'
+
+jest.mock('execa')
+
+afterEach(() => {
+  mock.restore()
+  jest.clearAllMocks()
+})
+
+describe('match pattern', () => {
+  it('issue #73 #125 - regex grouping (round pattern)', () => {
+    const onFoundChangedFiles = jest.fn()
+
+    mock({
+      '/.git': {},
+      '/src/apps/hello/foo.js': "export const foo = 'foo'",
+      '/src/libs/hello/bar.js': "export const bar = 'bar'",
+      '/src/tools/hello/baz.js': "export const baz = 'baz'",
+      '/src/should-not-be-included/hello/zoo.js': "export const zoo = 'zoo'",
+    })
+
+    // @ts-expect-error -- Need to find a better way to moch this
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+    execa.sync.mockImplementation((_command: string, args: string[]) => {
+      switch (args[0]) {
+        case 'ls-files': {
+          return { stdout: '' }
+        }
+        case 'diff': {
+          return args[2] === '--cached'
+            ? { stdout: '' }
+            : {
+                stdout: [
+                  '/src/apps/hello/foo.js',
+                  '/src/libs/hello/bar.js',
+                  '/src/tools/hello/baz.js',
+                  '/src/should-not-be-included/hello/zoo.js',
+                ].join('\n'),
+              }
+        }
+        default: {
+          throw new Error(`unexpected arg0: ${args[0]}`)
+        }
+      }
+    })
+
+    prettyQuick('root', {
+      pattern: '**/(apps|libs|tools)/**/*',
+      since: 'fox', // This is required to prevent `scm.getSinceRevision` call
+      onFoundChangedFiles,
+    })
+
+    expect(onFoundChangedFiles).toHaveBeenCalledWith([
+      '/src/apps/hello/foo.js',
+      '/src/libs/hello/bar.js',
+      '/src/tools/hello/baz.js',
+    ])
+  })
+})


### PR DESCRIPTION
Closes #73 
Closes #125

By replacing the `multimatch` with `picomatch` in #180, I accidentally fix #73 and #125 (`multimatch` doesn't support regex grouping in the glob pattern, while `picomatch` supports). The PR adds test cases to verify that both issues have been fixed.