### PR TITLE
docs: simple-git-hooks requires npx or yarn to run in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ yarn add -D simple-git-hooks
 
 In `package.json`, add:
 
-```json
+```jsonc
 "simple-git-hooks": {
   "pre-commit": "yarn pretty-quick --staged" // or "npx pretty-quick --staged"
 }

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ In `package.json`, add:
 
 ```json
 "simple-git-hooks": {
-  "pre-commit": "pretty-quick --staged"
+  "pre-commit": "yarn pretty-quick --staged" // or "npx pretty-quick --staged"
 }
 ```
 


### PR DESCRIPTION
Just reduce an error for beginners

```
.git/hooks/pre-commit: line 12: pretty-quick: command not found
```