### PR TITLE
chore: replace find-up -> empathic

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "prettier": "^3.0.0"
   },
   "dependencies": {
-    "find-up": "^5.0.0",
+    "empathic": "^1.1.0",
     "ignore": "^7.0.3",
     "mri": "^1.2.0",
     "picocolors": "^1.1.1",

--- a/src/scms/git.ts
+++ b/src/scms/git.ts
@@ -1,7 +1,7 @@
 import path from 'path'
 
 import * as find from 'empathic/find'
-import { exec, Output } from 'tinyexec'
+import { type Output, exec } from 'tinyexec'
 
 export const name = 'git'
 

--- a/src/scms/git.ts
+++ b/src/scms/git.ts
@@ -1,46 +1,13 @@
-import fs from 'fs'
 import path from 'path'
 
-import findUp from 'find-up'
-import { Output, exec } from 'tinyexec'
+import * as find from 'empathic/find'
+import { exec, Output } from 'tinyexec'
 
 export const name = 'git'
 
 export const detect = (directory: string) => {
-  if (fs.existsSync(path.join(directory, '.git'))) {
-    return directory
-  }
-
-  const gitDirectory = findUp.sync('.git', {
-    cwd: directory,
-    type: 'directory',
-  })
-
-  const gitWorkTreeFile = findUp.sync('.git', {
-    cwd: directory,
-    type: 'file',
-  })
-
-  // if both of these are null then return null
-  if (!gitDirectory && !gitWorkTreeFile) {
-    return null
-  }
-
-  // if only one of these exists then return it
-  if (gitDirectory && !gitWorkTreeFile) {
-    return path.dirname(gitDirectory)
-  }
-
-  if (gitWorkTreeFile && !gitDirectory) {
-    return path.dirname(gitWorkTreeFile)
-  }
-
-  const gitRepoDirectory = path.dirname(gitDirectory!)
-  const gitWorkTreeDirectory = path.dirname(gitWorkTreeFile!)
-  // return the deeper of these two
-  return gitRepoDirectory.length > gitWorkTreeDirectory.length
-    ? gitRepoDirectory
-    : gitWorkTreeDirectory
+  const found = find.up('.git', { cwd: directory })
+  return found ? path.dirname(found) : null
 }
 
 const runGit = (directory: string, args: string[]) =>

--- a/src/scms/hg.ts
+++ b/src/scms/hg.ts
@@ -1,18 +1,13 @@
 import path from 'path'
 
-import findUp from 'find-up'
-import { Output, exec } from 'tinyexec'
+import * as find from 'empathic/find'
+import { exec, Output } from 'tinyexec'
 
 export const name = 'hg'
 
 export const detect = (directory: string) => {
-  const hgDirectory = findUp.sync('.hg', {
-    cwd: directory,
-    type: 'directory',
-  })
-  if (hgDirectory) {
-    return path.dirname(hgDirectory)
-  }
+  const found = find.up('.hg', { cwd: directory })
+  if (found) return path.dirname(found)
 }
 
 const runHg = (directory: string, args: string[]) =>

--- a/src/scms/hg.ts
+++ b/src/scms/hg.ts
@@ -1,3 +1,4 @@
+import fs from 'fs'
 import path from 'path'
 
 import * as find from 'empathic/find'
@@ -7,7 +8,9 @@ export const name = 'hg'
 
 export const detect = (directory: string) => {
   const found = find.up('.hg', { cwd: directory })
-  if (found) return path.dirname(found)
+  if (found && fs.statSync(found).isDirectory()) {
+    return path.dirname(found)
+  }
 }
 
 const runHg = (directory: string, args: string[]) =>

--- a/src/scms/hg.ts
+++ b/src/scms/hg.ts
@@ -1,7 +1,7 @@
 import path from 'path'
 
 import * as find from 'empathic/find'
-import { exec, Output } from 'tinyexec'
+import { type Output, exec } from 'tinyexec'
 
 export const name = 'hg'
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6625,6 +6625,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"empathic@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "empathic@npm:1.1.0"
+  checksum: 1e41763802f14e5fa2522063f8f93e161c64916698f39e493a3e274356e39aa6f60d60f33063c92f9d5c5426fd33d9cb33baed2885a194648254181ce5495a9c
+  languageName: node
+  linkType: hard
+
 "encoding@npm:^0.1.13":
   version: 0.1.13
   resolution: "encoding@npm:0.1.13"
@@ -12934,8 +12941,8 @@ __metadata:
     "@types/picomatch": ^3.0.2
     "@unts/patch-package": ^8.1.1
     clean-pkg-json: ^1.2.0
+    empathic: ^1.1.0
     eslint: ^8.57.1
-    find-up: ^5.0.0
     ignore: ^7.0.3
     jest: ^29.7.0
     lint-staged: ^15.4.3


### PR DESCRIPTION
> Disclaimer: I am the author of [`empathic`](https://github.com/lukeed/empathic)

Replaces `find-up` with a much lighter-weight, faster alternative. Doing so cleans up the `detect` logic (since there's no difference in handling `.git` files or directories) and significantly (for this module) cleans up [the dependency graph](https://npmgraph.js.org/?q=pretty-quick).

* tests pass
* `engines.node` match
* native ESM and native CJS are both offered 

This is part of the [e18e](https://github.com/e18e/ecosystem-issues/issues/158) initiative, which I believe @JounQin is active within.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Replace `find-up` with `empathic` in `git.ts` and `hg.ts`, simplifying detection logic and reducing dependencies.
> 
>   - **Dependencies**:
>     - Replace `find-up` with `empathic` in `package.json`.
>   - **Code Changes**:
>     - Simplify `detect` function in `git.ts` and `hg.ts` using `empathic`.
>     - Remove `fs` import from `git.ts` as it's no longer needed.
>   - **Misc**:
>     - All tests pass, ensuring compatibility with the new dependency.
>     - `engines.node` remains compatible with the new package.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=prettier%2Fpretty-quick&utm_source=github&utm_medium=referral)<sup> for 73c364d1bd832d5832ae0e4e0d5f90750bf4722a. You can [customize](https://app.ellipsis.dev/prettier/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated dependencies by replacing "find-up" with "empathic".
  - Simplified internal logic for detecting project directories, improving efficiency and maintainability. No changes to user-facing features or functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->