### PR TITLE
fix: tinyexec v1 is esm only, use 0.x instead

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -10,7 +10,7 @@
   "fixed": [],
   "linked": [],
   "access": "public",
-  "baseBranch": "master",
+  "baseBranch": "4.x",
   "updateInternalDependencies": "patch",
   "ignore": []
 }

--- a/.changeset/short-rocks-count.md
+++ b/.changeset/short-rocks-count.md
@@ -1,0 +1,5 @@
+---
+"pretty-quick": patch
+---
+
+fix: tinyexec v1 is esm only, use 0.x instead

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ jobs:
           - 18
           - 20
           - 22
+          - 24
         os:
           - ubuntu-latest
       fail-fast: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release
 on:
   push:
     branches:
-      - master
+      - 4.x
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "lint:es": "eslint . --cache",
     "lint:tsc": "tsc --noEmit",
     "prepare": "patch-package && simple-git-hooks",
-    "release": "yarn build && clean-pkg-json && changeset publish",
+    "release": "yarn build && clean-pkg-json && changeset publish --tag release-v4",
     "test": "jest"
   },
   "peerDependencies": {
@@ -74,7 +74,7 @@
     "mri": "^1.2.0",
     "picocolors": "^1.1.1",
     "picomatch": "^4.0.2",
-    "tinyexec": "^1.0.1",
+    "tinyexec": "^0.3.2",
     "tslib": "^2.8.1"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -11492,7 +11492,7 @@ __metadata:
     simple-git-hooks: ^2.13.0
     size-limit: ^11.2.0
     size-limit-preset-node-lib: ^0.4.0
-    tinyexec: ^1.0.1
+    tinyexec: ^0.3.2
     ts-jest: ^29.3.4
     ts-node: ^10.9.2
     tsdown: ^0.12.5
@@ -13727,6 +13727,13 @@ __metadata:
   version: 2.3.8
   resolution: "through@npm:2.3.8"
   checksum: a38c3e059853c494af95d50c072b83f8b676a9ba2818dcc5b108ef252230735c54e0185437618596c790bbba8fcdaef5b290405981ffa09dce67b1f1bf190cbd
+  languageName: node
+  linkType: hard
+
+"tinyexec@npm:^0.3.2":
+  version: 0.3.2
+  resolution: "tinyexec@npm:0.3.2"
+  checksum: bd491923020610bdeadb0d8cf5d70e7cbad5a3201620fd01048c9bf3b31ffaa75c33254e1540e13b993ce4e8187852b0b5a93057bb598e7a57afa2ca2048a35c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
close #211
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Downgrade `tinyexec` to `^0.3.2`, add Node.js 24 to CI, and update release workflow for `4.x` branch.
> 
>   - **Dependencies**:
>     - Downgrade `tinyexec` from `^1.0.1` to `^0.3.2` in `package.json` to ensure compatibility.
>   - **CI Workflow**:
>     - Add Node.js version 24 to the matrix in `ci.yml`.
>   - **Release Workflow**:
>     - Change release branch from `master` to `4.x` in `release.yml`.
>     - Modify `release` script in `package.json` to use `--tag release-v4`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=prettier%2Fpretty-quick&utm_source=github&utm_medium=referral)<sup> for 956ae9d0f0787b6c7bd600e7eadb18e045a5ac89. You can [customize](https://app.ellipsis.dev/prettier/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated configuration and workflows to use the "4.x" branch instead of "master".
	- Expanded CI testing to include Node.js 24.
	- Adjusted release scripts to use a new release tag.
	- Downgraded the tinyexec dependency to version 0.x for compatibility.
	- Added documentation regarding tinyexec versioning and ESM-only support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->