### PR TITLE
fix: v4 should use latest npm tag

### DIFF
--- a/.changeset/two-bottles-fix.md
+++ b/.changeset/two-bottles-fix.md
@@ -1,0 +1,5 @@
+---
+"pretty-quick": patch
+---
+
+fix: v4 should use latest npm tag

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "lint:es": "eslint . --cache",
     "lint:tsc": "tsc --noEmit",
     "prepare": "patch-package && simple-git-hooks",
-    "release": "yarn build && clean-pkg-json && changeset publish --tag release-v4",
+    "release": "yarn build && clean-pkg-json && changeset publish",
     "test": "jest"
   },
   "peerDependencies": {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update `release` script in `package.json` to use default npm tag instead of `release-v4`.
> 
>   - **Scripts**:
>     - Update `release` script in `package.json` to use default npm tag instead of `release-v4`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=prettier%2Fpretty-quick&utm_source=github&utm_medium=referral)<sup> for 84ed20e330bf33fc5a468233c24e1fcf63e561b8. You can [customize](https://app.ellipsis.dev/prettier/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->