### PR TITLE
fix: tinyexec v1 is esm only, use 0.x instead temporarily

### DIFF
--- a/.changeset/good-cougars-obey.md
+++ b/.changeset/good-cougars-obey.md
@@ -1,0 +1,5 @@
+---
+"pretty-quick": patch
+---
+
+fix: tinyexec v1 is esm only, use 0.x instead temporarily

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "mri": "^1.2.0",
     "picocolors": "^1.1.1",
     "picomatch": "^4.0.2",
-    "tinyexec": "^1.0.1",
+    "tinyexec": "^0.3.2",
     "tslib": "^2.8.1"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -11066,7 +11066,7 @@ __metadata:
     simple-git-hooks: ^2.13.0
     size-limit: ^11.2.0
     size-limit-preset-node-lib: ^0.4.0
-    tinyexec: ^1.0.1
+    tinyexec: ^0.3.2
     ts-jest: ^29.3.4
     ts-node: ^10.9.2
     tsdown: ^0.12.5
@@ -13258,6 +13258,13 @@ __metadata:
   version: 2.3.8
   resolution: "through@npm:2.3.8"
   checksum: a38c3e059853c494af95d50c072b83f8b676a9ba2818dcc5b108ef252230735c54e0185437618596c790bbba8fcdaef5b290405981ffa09dce67b1f1bf190cbd
+  languageName: node
+  linkType: hard
+
+"tinyexec@npm:^0.3.2":
+  version: 0.3.2
+  resolution: "tinyexec@npm:0.3.2"
+  checksum: bd491923020610bdeadb0d8cf5d70e7cbad5a3201620fd01048c9bf3b31ffaa75c33254e1540e13b993ce4e8187852b0b5a93057bb598e7a57afa2ca2048a35c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Downgrade `tinyexec` to `^0.3.2` in `package.json` due to ESM-only support in version 1.x.
> 
>   - **Dependencies**:
>     - Downgrade `tinyexec` from `^1.0.1` to `^0.3.2` in `package.json` due to ESM-only support in version 1.x.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=prettier%2Fpretty-quick&utm_source=github&utm_medium=referral)<sup> for 88fef75b6cc12a7d3440038d80665869f718373a. You can [customize](https://app.ellipsis.dev/prettier/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Resolved compatibility issues by reverting the "tinyexec" dependency to an earlier version.

- **Chores**
  - Updated documentation to reflect the dependency change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->